### PR TITLE
Update partcl to recent parrot

### DIFF
--- a/runtime/tcllib.pir
+++ b/runtime/tcllib.pir
@@ -11,6 +11,7 @@ providing a compreg-compatible method.
 .HLL 'parrot'
 
 .loadlib 'tcl_ops'
+.loadlib 'tcl_group'
 .loadlib 'bit_ops'        # from parrot
 .loadlib 'io_ops'         # from parrot
 .loadlib 'trans_ops'      # from parrot

--- a/src/binary.c
+++ b/src/binary.c
@@ -314,10 +314,10 @@ PMC *ParTcl_binary_scan(PARROT_INTERP, STRING *BINSTR, STRING *FORMAT)
     /* make sure we've found the type numbers for the PMCs we want to create */
     if (!class_TclFloat)
     {
-        class_TclFloat  = pmc_type(interp, string_from_literal(interp, "TclFloat"));
-        class_TclInt    = pmc_type(interp, string_from_literal(interp, "TclInt"));
-        class_TclList   = pmc_type(interp, string_from_literal(interp, "TclList"));
-        class_TclString = pmc_type(interp, string_from_literal(interp, "TclString"));
+        class_TclFloat  = Parrot_pmc_get_type_str(interp, string_from_literal(interp, "TclFloat"));
+        class_TclInt    = Parrot_pmc_get_type_str(interp, string_from_literal(interp, "TclInt"));
+        class_TclList   = Parrot_pmc_get_type_str(interp, string_from_literal(interp, "TclList"));
+        class_TclString = Parrot_pmc_get_type_str(interp, string_from_literal(interp, "TclString"));
     }
 
     values = pmc_new(interp, class_TclList);

--- a/src/pmc/tclfloat.pmc
+++ b/src/pmc/tclfloat.pmc
@@ -18,8 +18,8 @@ pmclass TclFloat
 {
 
     VTABLE void class_init() {
-        dynpmc_TclInt    = pmc_type(INTERP, CONST_STRING(INTERP, "TclInt"));
-        dynpmc_TclString = pmc_type(INTERP, CONST_STRING(INTERP, "TclString"));
+        dynpmc_TclInt    = Parrot_pmc_get_type_str(INTERP, CONST_STRING(INTERP, "TclInt"));
+        dynpmc_TclString = Parrot_pmc_get_type_str(INTERP, CONST_STRING(INTERP, "TclString"));
     }
 
     VTABLE void set_integer_native(INTVAL value) {

--- a/src/pmc/tclint.pmc
+++ b/src/pmc/tclint.pmc
@@ -18,8 +18,8 @@ pmclass TclInt
 {
 
     VTABLE void class_init() {
-        dynpmc_TclFloat  = pmc_type(INTERP, CONST_STRING(INTERP, "TclFloat"));
-        dynpmc_TclString = pmc_type(INTERP, CONST_STRING(INTERP, "TclString"));
+        dynpmc_TclFloat  = Parrot_pmc_get_type_str(INTERP, CONST_STRING(INTERP, "TclFloat"));
+        dynpmc_TclString = Parrot_pmc_get_type_str(INTERP, CONST_STRING(INTERP, "TclString"));
     }
 
     VTABLE void set_number_native(FLOATVAL value) {

--- a/src/pmc/tclstring.pmc
+++ b/src/pmc/tclstring.pmc
@@ -20,8 +20,8 @@ pmclass TclString
 
 
     VTABLE void class_init() {
-        dynpmc_TclFloat = pmc_type(INTERP, CONST_STRING(INTERP, "TclFloat"));
-        dynpmc_TclInt   = pmc_type(INTERP, CONST_STRING(INTERP, "TclInt"));
+        dynpmc_TclFloat = Parrot_pmc_get_type_str(INTERP, CONST_STRING(INTERP, "TclFloat"));
+        dynpmc_TclInt   = Parrot_pmc_get_type_str(INTERP, CONST_STRING(INTERP, "TclInt"));
     }
 
     VTABLE void set_number_native(FLOATVAL value) {


### PR DESCRIPTION
This fixes the non-memory corruption error in #2.

With this, partcl builds on OS X 10.7.  It does, however, fail an astonishing number of tests.
